### PR TITLE
Golang Dag - Added public implementation of Diagnostic

### DIFF
--- a/diagnostic_base.go
+++ b/diagnostic_base.go
@@ -1,0 +1,26 @@
+package dag
+
+type diagnosticBase struct {
+	severity dag.Severity
+	summary  string
+	detail   string
+}
+
+func Diagnostic(severity dag.Severity, summary, detail string) dag.Diagnostic {
+	return diagnosticBase{
+		severity: severity,
+		summary:  summary,
+		detail:   detail,
+	}
+}
+
+func (d diagnosticBase) Severity() dag.Severity {
+	return d.severity
+}
+
+func (d diagnosticBase) Description() dag.Description {
+	return dag.Description{
+		Summary: d.summary,
+		Detail:  d.detail,
+	}
+}


### PR DESCRIPTION
There's currently no way to create a `Diagnostic` type from this library.

This implements a function that can be passed through to the Diagnostic interface, that is a slightly modified version of the Terraform Library [1][2]

1. https://github.com/hashicorp/terraform/blob/main/internal/tfdiags/sourceless.go
2. https://github.com/hashicorp/terraform/blob/main/internal/tfdiags/diagnostic_base.go